### PR TITLE
Build docker image with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2
+jobs:
+  build:
+    docker:
+    working_directory: ~/workdir
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image tiliado/nuvolasdk-ci:$CIRCLE_BRANCH
+          command: cd circleci-image && docker build -t tiliado/nuvolasdk-ci:$CIRCLE_BRANCH .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,11 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: circleci/golang:latest
+    machine: # for docker --privileged
+      image: circleci/classic:latest
     working_directory: ~/workdir
     steps:
       - checkout
-      - setup_remote_docker
       - run:
           name: Build Docker image tiliado/nuvolasdk-ci:$CIRCLE_BRANCH
           command: cd circleci-image && docker build -t tiliado/nuvolasdk-ci:$CIRCLE_BRANCH .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/classic:latest
+      - image: circleci/golang:latest
     working_directory: ~/workdir
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,16 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Build Docker image tiliado/nuvolasdk-ci:$CIRCLE_BRANCH
-          command: cd circleci-image && docker build -t tiliado/nuvolasdk-ci:$CIRCLE_BRANCH .
+          name: Build & push Docker image tiliado/nuvolasdk-ci
+          command: |
+            if [ "$CIRCLE_BRANCH" = 'master' ]; then
+                TAG=latest
+            else
+                TAG="$CIRCLE_BRANCH"
+            fi
+            IMAGE="tiliado/nuvolasdk-ci:$TAG"
+            echo -e "\n\n~~~~ Building $IMAGE ~~~~\n"
+            cd circleci-image
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker build -t "$IMAGE" .
+            docker push "$IMAGE"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2
 jobs:
   build:
     docker:
+      - image: circleci/classic:latest
     working_directory: ~/workdir
     steps:
       - checkout


### PR DESCRIPTION
The image is built and published to Docker Hub as tiliado/nuvolasdk-ci.

Issue: tiliado/nuvolasdk#11
