### PR TITLE
Add X-GNOME-UsesNotifications= to desktop files

### DIFF
--- a/nuvolasdk/data/launcher.desktop
+++ b/nuvolasdk/data/launcher.desktop
@@ -7,3 +7,4 @@ Icon=@@ICON@@
 StartupWMClass=@@APP_UID@@
 StartupNotify=true
 Terminal=false
+X-GNOME-UsesNotifications=true


### PR DESCRIPTION
Some GNOME components expect this information to tell that the application sends notifications.

See https://docs.elementary.io/develop/apis/notifications#making-preparations, https://wiki.gnome.org/Initiatives/GnomeGoals/NotificationSource